### PR TITLE
move common region text styling to class

### DIFF
--- a/RegionMap.svg
+++ b/RegionMap.svg
@@ -7,7 +7,6 @@
       fill-opacity: 10%;
     }
 
-    
     .borderlines {
       stroke-linecap: round;
       stroke-linejoin: round;
@@ -25,6 +24,14 @@
     .tenkgrid {
       stroke: #004040;
       stroke-width: 0.5px;
+    }
+
+    .regionText {
+      font: 30px sans-serif;
+      fill: white;
+      text-anchor: middle;
+      dominant-baseline: middle;
+      pointer-events: none;
     }
   </style>
   <line x1="1021" y1="1014" x2="1021" y2="2048" class="radialgrid" transform="rotate(0 1021 1014)" />
@@ -41130,46 +41137,46 @@
              114.00,568.00 112.00,568.00 112.00,568.00
              112.00,568.00 112.00,567.00 112.00,567.00
              112.00,567.00 111.00,567.00 111.00,567.00 Z" />
-  <text id="Region_text_01" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1430px, 355px) rotate(30deg)">Acheron</text>
-  <text id="Region_text_02" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1455px, 1580px) rotate(-35deg)">Achilles's Altar</text>
-  <text id="Region_text_03" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(169px, 1152px) rotate(80deg)">Aquila's Halo</text>
-  <text id="Region_text_04" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1254px, 903px) rotate(65deg)">Arcadian Stream</text>
-  <text id="Region_text_05" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1609px, 1104px) rotate(-80deg)">Dryman's Point</text>
-  <text id="Region_text_06" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(800px, 1590px) rotate(20deg)">Elysian Shore</text>
-  <text id="Region_text_07" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1097px, 1048px) rotate(-60deg)">Empyrean Straits</text>
-  <text id="Region_text_08" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(390px, 1523px) rotate(50deg)">Errant Marches</text>
-  <text id="Region_text_09" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1034px, 475px)">Formorian Frontier</text>
-  <text id="Region_text_10" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1015px, 1010px) rotate(-60deg)"><tspan x="0" dy="-0.5em">Galactic</tspan><tspan x="0" dy="1em">Centre</tspan></text>
-  <text id="Region_text_11" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1367px, 1361px) rotate(-45deg)">Hawking's Gap</text>
-  <text id="Region_text_12" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(702px, 434px) rotate(-30deg)">Hieronymus Delta</text>
-  <text id="Region_text_13" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(957px, 1480px) rotate(5deg)">Inner Orion Spur</text>
-  <text id="Region_text_14" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(765px, 995px) rotate(-60deg)"><tspan x="0" dy="-1.5em">Inner</tspan><tspan x="0" dy="1em">Orion-Perseus</tspan><tspan x="0" dy="1em">Conflux</tspan></text>
-  <text id="Region_text_15" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(852px, 1280px) rotate(40deg)"><tspan x="-2em" dy="-1.5em">Inner</tspan><tspan x="0" dy="1em">Scutum-Centaurus</tspan><tspan x="2em" dy="1em">Arm</tspan></text>
-  <text id="Region_text_16" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(912px, 813px) rotate(-30deg)">Izanami</text>
-  <text id="Region_text_17" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1227px, 1866px) rotate(-15deg)">Kepler's Crest</text>
-  <text id="Region_text_18" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1656px, 1396px) rotate(-60deg)">Lyra's Song</text>
-  <text id="Region_text_19" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1646px, 565px) rotate(55deg)">Mare Somnia</text>
-  <text id="Region_text_20" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(908px, 663px) rotate(-15deg)">Newton's Vault</text>
-  <text id="Region_text_21" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1020px, 1231px)">Norma Arm</text>
-  <text id="Region_text_22" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1296px, 1217px) rotate(-45deg)">Norma Expanse</text>
-  <text id="Region_text_23" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(883px, 1055px) rotate(-80deg)">Odin's Hold</text>
-  <text id="Region_text_24" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(669px, 1157px) rotate(70deg)">Orion-Cygnus Arm</text>
-  <text id="Region_text_25" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(404px, 963px) rotate(-80deg)">Outer Arm</text>
-  <text id="Region_text_26" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1265px, 1530px) rotate(-25deg)">Outer Orion Spur</text>
-  <text id="Region_text_27" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(707px, 869px) rotate(-60deg)"><tspan x="-2em" dy="-1.5em">Outer</tspan><tspan x="0" dy="1em">Orion-Perseus</tspan><tspan x="2em" dy="1em">Conflux</tspan></text>
-  <text id="Region_text_28" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(389px, 414px) rotate(-45deg)">Outer Scutum-Centaurus Arm</text>
-  <text id="Region_text_29" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(546px, 1020px) rotate(-80deg)">Perseus Arm</text>
-  <text id="Region_text_30" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1023px, 900px)"><tspan x="0" dy="-0.5em">Ryker's</tspan><tspan x="0" dy="1em">Hope</tspan></text>
-  <text id="Region_text_31" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1646px, 839px) rotate(75deg)"><tspan x="0" dy="-1.0em">Sagittarius-</tspan><tspan x="0" dy="1em">Carina</tspan><tspan x="0" dy="1em">Arm</tspan></text>
-  <text id="Region_text_32" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1156px, 1678px) rotate(-10deg)">Sanguineous Rim</text>
-  <text id="Region_text_33" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(757px, 1375px) rotate(30deg)">Temple</text>
-  <text id="Region_text_34" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1874px, 1094px) rotate(-80deg)">Tenebrae</text>
-  <text id="Region_text_35" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(992px, 204px)">The Abyss</text>
-  <text id="Region_text_36" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(627px, 708px) rotate(-50deg)">The Conduit</text>
-  <text id="Region_text_37" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(712px, 1787px) rotate(20deg)">The Formidine Rift</text>
-  <text id="Region_text_38" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1304px, 660px) rotate(40deg)">The Veils</text>
-  <text id="Region_text_39" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(189px, 778px) rotate(-75deg)">The Void</text>
-  <text id="Region_text_40" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1417px, 906px) rotate(75deg)">Trojan Belt</text>
-  <text id="Region_text_41" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(591px, 1385px) rotate(50deg)">Vulcan Gate</text>
-  <text id="Region_text_42" style="font: 30px sans-serif; fill: white; text-anchor:middle; dominant-baseline: middle; pointer-events: none; transform: translate(1728px, 1607px) rotate(-50deg)">Xibalba</text>
+  <text id="Region_text_01" class="regionText" style="transform: translate(1430px, 355px) rotate(30deg)">Acheron</text>
+  <text id="Region_text_02" class="regionText" style="transform: translate(1455px, 1580px) rotate(-35deg)">Achilles's Altar</text>
+  <text id="Region_text_03" class="regionText" style="transform: translate(169px, 1152px) rotate(80deg)">Aquila's Halo</text>
+  <text id="Region_text_04" class="regionText" style="transform: translate(1254px, 903px) rotate(65deg)">Arcadian Stream</text>
+  <text id="Region_text_05" class="regionText" style="transform: translate(1609px, 1104px) rotate(-80deg)">Dryman's Point</text>
+  <text id="Region_text_06" class="regionText" style="transform: translate(800px, 1590px) rotate(20deg)">Elysian Shore</text>
+  <text id="Region_text_07" class="regionText" style="transform: translate(1097px, 1048px) rotate(-60deg)">Empyrean Straits</text>
+  <text id="Region_text_08" class="regionText" style="transform: translate(390px, 1523px) rotate(50deg)">Errant Marches</text>
+  <text id="Region_text_09" class="regionText" style="transform: translate(1034px, 475px)">Formorian Frontier</text>
+  <text id="Region_text_10" class="regionText" style="transform: translate(1015px, 1010px) rotate(-60deg)"><tspan x="0" dy="-0.5em">Galactic</tspan><tspan x="0" dy="1em">Centre</tspan></text>
+  <text id="Region_text_11" class="regionText" style="transform: translate(1367px, 1361px) rotate(-45deg)">Hawking's Gap</text>
+  <text id="Region_text_12" class="regionText" style="transform: translate(702px, 434px) rotate(-30deg)">Hieronymus Delta</text>
+  <text id="Region_text_13" class="regionText" style="transform: translate(957px, 1480px) rotate(5deg)">Inner Orion Spur</text>
+  <text id="Region_text_14" class="regionText" style="transform: translate(765px, 995px) rotate(-60deg)"><tspan x="0" dy="-1.5em">Inner</tspan><tspan x="0" dy="1em">Orion-Perseus</tspan><tspan x="0" dy="1em">Conflux</tspan></text>
+  <text id="Region_text_15" class="regionText" style="transform: translate(852px, 1280px) rotate(40deg)"><tspan x="-2em" dy="-1.5em">Inner</tspan><tspan x="0" dy="1em">Scutum-Centaurus</tspan><tspan x="2em" dy="1em">Arm</tspan></text>
+  <text id="Region_text_16" class="regionText" style="transform: translate(912px, 813px) rotate(-30deg)">Izanami</text>
+  <text id="Region_text_17" class="regionText" style="transform: translate(1227px, 1866px) rotate(-15deg)">Kepler's Crest</text>
+  <text id="Region_text_18" class="regionText" style="transform: translate(1656px, 1396px) rotate(-60deg)">Lyra's Song</text>
+  <text id="Region_text_19" class="regionText" style="transform: translate(1646px, 565px) rotate(55deg)">Mare Somnia</text>
+  <text id="Region_text_20" class="regionText" style="transform: translate(908px, 663px) rotate(-15deg)">Newton's Vault</text>
+  <text id="Region_text_21" class="regionText" style="transform: translate(1020px, 1231px)">Norma Arm</text>
+  <text id="Region_text_22" class="regionText" style="transform: translate(1296px, 1217px) rotate(-45deg)">Norma Expanse</text>
+  <text id="Region_text_23" class="regionText" style="transform: translate(883px, 1055px) rotate(-80deg)">Odin's Hold</text>
+  <text id="Region_text_24" class="regionText" style="transform: translate(669px, 1157px) rotate(70deg)">Orion-Cygnus Arm</text>
+  <text id="Region_text_25" class="regionText" style="transform: translate(404px, 963px) rotate(-80deg)">Outer Arm</text>
+  <text id="Region_text_26" class="regionText" style="transform: translate(1265px, 1530px) rotate(-25deg)">Outer Orion Spur</text>
+  <text id="Region_text_27" class="regionText" style="transform: translate(707px, 869px) rotate(-60deg)"><tspan x="-2em" dy="-1.5em">Outer</tspan><tspan x="0" dy="1em">Orion-Perseus</tspan><tspan x="2em" dy="1em">Conflux</tspan></text>
+  <text id="Region_text_28" class="regionText" style="transform: translate(389px, 414px) rotate(-45deg)">Outer Scutum-Centaurus Arm</text>
+  <text id="Region_text_29" class="regionText" style="transform: translate(546px, 1020px) rotate(-80deg)">Perseus Arm</text>
+  <text id="Region_text_30" class="regionText" style="transform: translate(1023px, 900px)"><tspan x="0" dy="-0.5em">Ryker's</tspan><tspan x="0" dy="1em">Hope</tspan></text>
+  <text id="Region_text_31" class="regionText" style="transform: translate(1646px, 839px) rotate(75deg)"><tspan x="0" dy="-1.0em">Sagittarius-</tspan><tspan x="0" dy="1em">Carina</tspan><tspan x="0" dy="1em">Arm</tspan></text>
+  <text id="Region_text_32" class="regionText" style="transform: translate(1156px, 1678px) rotate(-10deg)">Sanguineous Rim</text>
+  <text id="Region_text_33" class="regionText" style="transform: translate(757px, 1375px) rotate(30deg)">Temple</text>
+  <text id="Region_text_34" class="regionText" style="transform: translate(1874px, 1094px) rotate(-80deg)">Tenebrae</text>
+  <text id="Region_text_35" class="regionText" style="transform: translate(992px, 204px)">The Abyss</text>
+  <text id="Region_text_36" class="regionText" style="transform: translate(627px, 708px) rotate(-50deg)">The Conduit</text>
+  <text id="Region_text_37" class="regionText" style="transform: translate(712px, 1787px) rotate(20deg)">The Formidine Rift</text>
+  <text id="Region_text_38" class="regionText" style="transform: translate(1304px, 660px) rotate(40deg)">The Veils</text>
+  <text id="Region_text_39" class="regionText" style="transform: translate(189px, 778px) rotate(-75deg)">The Void</text>
+  <text id="Region_text_40" class="regionText" style="transform: translate(1417px, 906px) rotate(75deg)">Trojan Belt</text>
+  <text id="Region_text_41" class="regionText" style="transform: translate(591px, 1385px) rotate(50deg)">Vulcan Gate</text>
+  <text id="Region_text_42" class="regionText" style="transform: translate(1728px, 1607px) rotate(-50deg)">Xibalba</text>
 </svg>


### PR DESCRIPTION
unique styling via the `transform` is still inline

This brings the code in line with the version PR'd to the ED Region Map:
https://github.com/klightspeed/EliteDangerousRegionMap/pull/5

This PR also removes an empty line and trailing whitespace left on line 10 when the code section:
```css
    .region:hover {
      fill-opacity: 50%;
    }
```
was deleted in commit d4c63d4a77f976afc84abce584cbad0982270d55.