### PR TITLE
suggested formatting for gravity column

### DIFF
--- a/tablefiller.js
+++ b/tablefiller.js
@@ -103,7 +103,7 @@ document.addEventListener('recordSelected', function (event) {
                 <td>${system.distanceToArrival}</td>
                 <td>${system.orbitalEccentricity}</td>
                 <td>${system.temperature}</td>
-                <td>${system.gravity}</td>
+                <td>${system.gravity?.toFixed(2) ?? "?.??"}g</td>
                 
                 <td class="materials ${MatsToggle}">${AntimonyMaterial.toFixed(2)}%</td>
                 <td class="materials ${MatsToggle}">${PoloniumMaterial.toFixed(2)}%</td>


### PR DESCRIPTION
This would change the gravity field to look like the following:
![image](https://github.com/canonn-science/Codex-Regions/assets/1542264/47104d95-c182-4033-81db-166d6d47ab35)
![image](https://github.com/canonn-science/Codex-Regions/assets/1542264/641d4950-18ab-47f0-bb39-c07c390cda2f)

From the following (for reference):
![image](https://github.com/canonn-science/Codex-Regions/assets/1542264/5900938d-d042-4981-8ce0-aeae5ce5afc6)
![image](https://github.com/canonn-science/Codex-Regions/assets/1542264/99f85b9d-87e1-4ee1-967f-502fb9a6e776)

Makes the stylistic decision to turn `null` into `?.??g`.  Though technically, for 2 decimal places, it should be ?.?.
